### PR TITLE
feat(api): Add Gemma-powered web search endpoint

### DIFF
--- a/app/api/v1/endpoints/__init__.py
+++ b/app/api/v1/endpoints/__init__.py
@@ -3,5 +3,6 @@ from .clinical_trial_router import router as clinical_trial_router
 from .records import router as records_router
 from .websearch import router as websearch_router
 from .webscraper import router as webscraper_router
+from .gemma_web_search import router as gemma_web_search_router
 
-__all__ = ["chat_router", "clinical_trial_router", "records_router", "websearch_router", "webscraper_router"]
+__all__ = ["chat_router", "clinical_trial_router", "records_router", "websearch_router", "webscraper_router", "gemma_web_search_router"]

--- a/app/api/v1/endpoints/gemma_web_search.py
+++ b/app/api/v1/endpoints/gemma_web_search.py
@@ -1,0 +1,62 @@
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from app.models.gemma import GemmaPayload, Content, Part
+from app.core.api_request import api_request
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+
+router = APIRouter(tags=["gemma-web-search"])
+
+class GemmaWebSearchRequest(BaseModel):
+    prompt: str
+    context: str
+
+@router.post("/gemma-web-search")
+async def gemma_web_search(request: GemmaWebSearchRequest, http_request: Request) -> JSONResponse:
+    """
+    Take a prompt and context, generate a search query with Gemma,
+    and then call the /webscraper endpoint to perform a web search and scrape the results.
+    """
+    # 1. Generate search query with Gemma
+    gemma_prompt = f"Based on the following prompt and context, generate a concise and effective web search query. The query should be no more than 10 words. Return only the search query and nothing else.\n\nPrompt: {request.prompt}\n\nContext: {request.context}"
+    
+    payload = GemmaPayload(
+        contents=[
+            Content(
+                role="user",
+                parts=[Part(text=gemma_prompt)]
+            )
+        ]
+    )
+
+    try:
+        gemma_response = await api_request(payload, model="gemini-1.5-flash")
+        if gemma_response.get("status") != "success":
+            error_message = gemma_response.get("error_message", "Unknown error from api_request")
+            raise HTTPException(status_code=500, detail=f"Error from Gemma API: {error_message}")
+
+        search_query = gemma_response.get("data", "").strip()
+        if not search_query:
+            raise HTTPException(status_code=500, detail="Empty search query received from Gemma")
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error generating search query with Gemma: {e}")
+
+    # 2. Call the /webscraper endpoint
+    async with httpx.AsyncClient() as client:
+        webscraper_url = http_request.url_for("webscraper")
+        try:
+            response = await client.post(str(webscraper_url), json={"query": search_query})
+            response.raise_for_status()
+            webscraper_data = response.json()
+            
+            # Add the search query to the final response
+            final_response = {
+                "search_query": search_query,
+                "data": webscraper_data.get("data", [])
+            }
+            return JSONResponse(content=final_response)
+        except httpx.HTTPStatusError as e:
+            raise HTTPException(status_code=e.response.status_code, detail=f"Error from webscraper service: {e.response.text}")
+        except httpx.RequestError as e:
+            raise HTTPException(status_code=500, detail=f"Could not connect to webscraper service: {e}")

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -6,6 +6,7 @@ from app.api.v1.endpoints import (
     records_router,
     websearch_router,
     webscraper_router,
+    gemma_web_search_router,
 )
 
 router = APIRouter()
@@ -16,3 +17,4 @@ router.include_router(records_router)
 router.include_router(clinical_trial_router)
 router.include_router(websearch_router)
 router.include_router(webscraper_router)
+router.include_router(gemma_web_search_router)


### PR DESCRIPTION
This commit introduces a new endpoint, `/gemma-web-search`, which orchestrates an intelligent search process.

The endpoint accepts a user prompt and context, then uses the Gemma model to generate a concise web search query. This generated query is subsequently passed to the existing `/webscraper` endpoint to fetch and return the search results.

The final response includes both the AI-generated search query and the scraped data.